### PR TITLE
Add example.ts. Move package.json, tsconfig.json to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type":"module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test":"ts-node --esm src/example.ts"
   },
   "repository": {
     "type": "git",

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,0 +1,40 @@
+import { exit } from 'process';
+import {$, fs, ProcessOutput} from 'zx';
+
+async function workTreeIsClean() {
+  try{
+    await $`git diff-index --quiet HEAD .`;
+    return true; // zero exit code : tree clean
+  }
+  catch(err){
+    if(err instanceof ProcessOutput && err.exitCode !== 0){
+      return false; // non zero : tree unclean
+    }
+    throw err; // unexpected error
+  }
+}
+
+async function loadPackageJson() {
+  const packageJson = await fs.readJSON('./package.json');
+  return packageJson as {
+    name: string;
+    version: string;
+  };
+}
+
+async function bumpPackageVersion() {
+  if (!(await workTreeIsClean())) {
+    console.log('You have uncommitted files in your git worktree. Halting')
+    exit(1);
+  }
+  await $`npm version patch`;
+  const { version } = await loadPackageJson();
+  await $`git commit -m "Increment version to '${version}'" package.json`;
+  await $`git push`;
+}
+
+async function release() {
+  await bumpPackageVersion();
+}
+
+void release();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,9 +24,9 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "esnext",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
Working configuration of ts-node with zx. To prove it, run `npm install && npm run test`.

Fixes https://github.com/cefn/zx-tsnode-repro/issues/1 which contains more detail of the issue.