### PR TITLE
Typescript import extension resolve bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type":"module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test":"ts-node --esm src/example.ts"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "type":"module",
+  "type": "module",
   "scripts": {
-    "test":"ts-node --esm src/example.ts"
+    "test:good": "ts-node --esm src/example.ts",
+    "test:bad": "ts-node --esm tooling/specialpurpose.ts"
   },
   "repository": {
     "type": "git",

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,0 +1,40 @@
+import { exit } from 'process';
+import {$, fs, ProcessOutput} from 'zx';
+
+async function workTreeIsClean() {
+  try{
+    await $`git diff-index --quiet HEAD .`;
+    return true; // zero exit code : tree clean
+  }
+  catch(err){
+    if(err instanceof ProcessOutput && err.exitCode !== 0){
+      return false; // non zero : tree unclean
+    }
+    throw err; // unexpected error
+  }
+}
+
+async function loadPackageJson() {
+  const packageJson = await fs.readJSON('./package.json');
+  return packageJson as {
+    name: string;
+    version: string;
+  };
+}
+
+async function bumpPackageVersion() {
+  if (!(await workTreeIsClean())) {
+    console.log('You have uncommitted files in your git worktree. Halting')
+    exit(1);
+  }
+  await $`npm version patch`;
+  const { version } = await loadPackageJson();
+  await $`git commit -m "Increment version to '${version}'" package.json`;
+  await $`git push`;
+}
+
+async function release() {
+  await bumpPackageVersion();
+}
+
+void release();

--- a/tooling/lib/util.ts
+++ b/tooling/lib/util.ts
@@ -1,0 +1,3 @@
+export function utilityFunction(){
+    console.log("Hello World!");
+}

--- a/tooling/specialpurpose.ts
+++ b/tooling/specialpurpose.ts
@@ -1,0 +1,3 @@
+import { utilityFunction } from "./lib/util"
+
+utilityFunction()

--- a/tooling/specialpurpose.ts
+++ b/tooling/specialpurpose.ts
@@ -1,3 +1,3 @@
-import { utilityFunction } from "./lib/util"
+import { utilityFunction } from "./lib/util.js"
 
 utilityFunction()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,9 +24,9 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "esnext",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
This demonstrates a 'bug' when using relative imports with zx and ts-node, which causes e.g. `./util.ts` not to be loadable as `./util`. 

This branch is based on the [use-zx branch](https://github.com/cefn/zx-tsnode-repro/tree/use-zx) which proved zx operating with ts-node (but required lots of package and tsconfig changes towards ESM to make it work).

You can see the bug by running `npm install && npm run test:bad` against commit  [dd53043](https://github.com/cefn/zx-tsnode-repro/commit/dd5304347ffac6bd2692678b751e69b5266f402d) in this PR branch.

The commit added a tooling 'script' with a relative import of a tooling 'library' which is at `/Users/cefn/Documents/cefn/github/zx-tsnode-repro/tooling/lib/util.ts` but cannot be imported like `util` or `util.ts` but has to be imported as `util.js` before it will run.

The error appears as follows, saying the file is not there, although the path is exactly correct (minus `.ts`)

```
> zx-tsnode-repro@1.0.0 test:bad
> ts-node --esm tooling/specialpurpose.ts

/Users/cefn/Documents/cefn/github/zx-tsnode-repro/node_modules/ts-node/dist-raw/node-esm-resolve-implementation.js:383
    throw new ERR_MODULE_NOT_FOUND(
          ^
CustomError: Cannot find module '/Users/cefn/Documents/cefn/github/zx-tsnode-repro/tooling/lib/util' imported from /Users/cefn/Documents/cefn/github/zx-tsnode-repro/tooling/specialpurpose.ts
    at finalizeResolution (/Users/cefn/Documents/cefn/github/zx-tsnode-repro/node_modules/ts-node/dist-raw/node-esm-resolve-implementation.js:383:11)
    at moduleResolve (/Users/cefn/Documents/cefn/github/zx-tsnode-repro/node_modules/ts-node/dist-raw/node-esm-resolve-implementation.js:818:10)
    at Object.defaultResolve (/Users/cefn/Documents/cefn/github/zx-tsnode-repro/node_modules/ts-node/dist-raw/node-esm-resolve-implementation.js:929:11)
    at /Users/cefn/Documents/cefn/github/zx-tsnode-repro/node_modules/ts-node/src/esm.ts:228:33
    at entrypointFallback (/Users/cefn/Documents/cefn/github/zx-tsnode-repro/node_modules/ts-node/src/esm.ts:179:34)
    at resolve (/Users/cefn/Documents/cefn/github/zx-tsnode-repro/node_modules/ts-node/src/esm.ts:227:12)
    at resolve (/Users/cefn/Documents/cefn/github/zx-tsnode-repro/node_modules/ts-node/src/child/child-loader.ts:19:39)
    at ESMLoader.resolve (node:internal/modules/esm/loader:530:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:251:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:79:40)
```

Adding the final commit [2a5228e](https://github.com/cefn/zx-tsnode-repro/commit/2a5228e1bd3aff87806c9ec7292e093ba28afb93) is required for the code to run, which seems surprising and may be a bug. 

![image](https://user-images.githubusercontent.com/159819/169640624-22f42cde-9c17-4278-861c-526600761a0d.png)
